### PR TITLE
Fix outerEl null ref causing error when removing Dragger from page

### DIFF
--- a/example/src/Example1.js
+++ b/example/src/Example1.js
@@ -17,26 +17,29 @@ const Example1 = () => {
   const [isDisabled, setIsDisabled] = useState(false)
   const [friction, setFriction] = useState(0.9)
   const [clickedItem, setClickedItem] = useState(null)
+  const [isMounted, setIsMounted] = useState(true)
   const draggerRef = useRef(null)
 
   return (
     <section className='section'>
-      <Dragger
-        // Dragger internals are exposed via its ref
-        draggerRef={r => draggerRef.current = r}
-        disabled={isDisabled}
-        ResizeObserver={ResizeObserver}
-        friction={friction}
-        onFrame={frame => setFrame(frame)}
-        className='dragger'
-        onStaticClick={el => {
-          if (el.nodeName === 'BUTTON') setClickedItem(el.textContent)
-        }}
-      >
-        {items.map((item, i) => (
-          <button className='item-standard' key={`${item}-${i}`}>{item}</button>
-        ))}
-      </Dragger>
+      {isMounted &&
+        <Dragger
+          // Dragger internals are exposed via its ref
+          draggerRef={r => draggerRef.current = r}
+          disabled={isDisabled}
+          ResizeObserver={ResizeObserver}
+          friction={friction}
+          onFrame={frame => setFrame(frame)}
+          className='dragger'
+          onStaticClick={el => {
+            if (el.nodeName === 'BUTTON') setClickedItem(el.textContent)
+          }}
+        >
+          {items.map((item, i) => (
+            <button className='item-standard' key={`${item}-${i}`}>{item}</button>
+          ))}
+        </Dragger>
+      }
 
       <div className='button-group'>
         <button className='btn' onClick={() => setIsDisabled(!isDisabled)}>
@@ -116,6 +119,12 @@ const Example1 = () => {
           }}
         >
           Right edge
+        </button>
+        <button
+          className="btn"
+          onClick={() => setIsMounted(!isMounted)}
+        >
+          {isMounted ? 'Unmount' : 'Mount'} component
         </button>
       </div>
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -150,6 +150,11 @@ const Dragger: React.FC<PropsWithDefaults> = props => {
   }
 
   function updateLoop(optionalFinalPosition: any) {
+    // bail out of the loop if the component has been unmounted
+    if (!outerEl.current) {
+      window.cancelAnimationFrame(rafId.current)
+      return
+    }
 
     velocityX.current *= settings.current.friction
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,7 +79,7 @@ const Dragger: React.FC<PropsWithDefaults> = props => {
     const { left, right }: { left: number; right: number } = getBoundaries({
       outerWidth: outerWidth.current,
       innerWidth: innerWidth.current,
-      elClientLeft: outerEl.current.clientLeft
+      elClientLeft: outerEl.current && outerEl.current.clientLeft || 0
     })
 
     leftBound.current = left
@@ -103,7 +103,7 @@ const Dragger: React.FC<PropsWithDefaults> = props => {
       const { left, right }: { left: number; right: number } = getBoundaries({
         outerWidth: outerWidth.current,
         innerWidth: innerWidth.current,
-        elClientLeft: outerEl.current.clientLeft
+        elClientLeft: outerEl.current && outerEl.current.clientLeft || 0,
       })
 
       leftBound.current = left


### PR DESCRIPTION
This fixes #16 by checking to see if the ref exists and defaulting to a clientLeft of 0 if it doesn't.