### PR TITLE
Fix for crash when you switch route but anim is still going on

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -216,8 +216,10 @@ const Dragger: React.FC<PropsWithDefaults> = props => {
       restPositionX.current = roundNum(nativePosition.current)
     } else {
       // bypass Reacts render method during animation, similar to react-spring
-      innerEl.current.style.transform = `translate3d(${roundNum(nativePosition.current)}px,0,0)`
-      rafId.current = window.requestAnimationFrame(() => { updateLoop(null) })
+      if(innerEl.current) {
+      	innerEl.current.style.transform = `translate3d(${roundNum(nativePosition.current)}px,0,0)`
+      	rafId.current = window.requestAnimationFrame(() => { updateLoop(null) })
+	  }
     }
 
     if (props.onFrame) {


### PR DESCRIPTION
Hi Nick,

a great library, students of mine like it at lot :) 

There is just a little issue with crashes, when you use the library together with React-Router.

When you perform a slide which is not completed yet and meanwhile switch the route (some people really do that ;)) then setting the given ref in the given line (see fix in file) will be undefined. And cause the crash. The little if check before setting the ref prevents that and makes it more stable.

Hope it gets included, it's just just a very small fix :) 

Cheers from Berlin
Rob